### PR TITLE
fix rect syntax in cheatsheet

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -29,7 +29,7 @@
 (style (stroke "blue" 20 :cap "round") p)
 
 ;; パス
-(rect [0 0] [20 20])
+(rect [0 0 20 20])
 (circle [0 0] 100)
 (line [0 0] [100 100])
 (ellipse [0 0] [40 60])


### PR DESCRIPTION
[x y w h] instead of [x y] [w h]