### PR TITLE
Fix broken link to EN documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 - [Demo (Chrome Only)](https://glisp.app)
 - Documentation
-  - [🇺🇸 English](https://glisp.app/docs/en)
+  - [🇺🇸 English](https://glisp.app/docs/#/en/)
   - [🇯🇵 日本語](https://glisp.app/docs)
 
 Glisp, an acronym for **G**raphical **LISP**, is the prototyping project to experiment what if a design tool meets a way of creative coding, and obtain the self-bootstrapping power of LISP.


### PR DESCRIPTION
The link pointing to the EN documentation was showing a 403 page. I found the correct one through the Japanese version under Translations, only a ""#" was missing.

Thank you for this awesome project and i am looking forward to playing around with it and hopefully maybe helping you out if i can.