### PR TITLE
fix combination/product bug

### DIFF
--- a/public/lib/math.glisp
+++ b/public/lib/math.glisp
@@ -894,7 +894,7 @@
     (map #(vector %) (first xs))
     (apply concat
            (map
-            (fn [R] (map #(vec (cons R %)) (last xs)))
+            (fn [R] (map #(vec (concat R %)) (last xs)))
             (if (= 2 (count xs))
               (first xs)
               (apply combination/product (butlast xs)))))))


### PR DESCRIPTION
it's broken when the input has 3 sets.
This bug affects `for`, so it breaks if more than 3 vars are defined.

previous behavior:
```lisp
(combination/product [1 11] [2 22] [3 33])
;=>
[[1 2] 3]
[[1 2] 33]
[[1 22] 3]
[[1 22] 33]
[[11 2] 3]
[[11 2] 33]
[[11 22] 3]
[[11 22] 33]
```



BTW, I can't `yarn repl` after `yarn install`
```log
$ yarn repl

> glisp@0.1.0 repl /Users/miyamonz/go/src/github.com/miyamonz/glisp
> node ./repl/index.js

Error: ENOENT: no such file or directory, open '/Users/baku/Sites/glisp/repl/lib/core.glisp'
```

so I only tested on a browser manually.
https://glisp.app/commit:9bce3f6/?code_url=https://gist.githubusercontent.com/miyamonz/5310b09eb276e170f03be606b96a329e/raw/72f7541b25a2a35abf24e31989fab726e72c296d/sketch_sep-11-2020_22-31-24.glisp.glisp

and I couldn't find out how to run tests and where to write my test.
According to test.js, maybe the test setting is only for your PC currently. isn't it?